### PR TITLE
Add NetStandard 2.0 target

### DIFF
--- a/src/NaturalSort.Extension/NaturalSort.Extension.csproj
+++ b/src/NaturalSort.Extension/NaturalSort.Extension.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Label="Basic build">
-    <TargetFrameworks>netstandard1.3;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;netstandard2.0;net6.0</TargetFrameworks>
     <LangVersion>10</LangVersion>
     <Deterministic>true</Deterministic>
   </PropertyGroup>


### PR DESCRIPTION
NetStandard 1.x bring .NET Library as explicit dependency.
![image](https://github.com/tompazourek/NaturalSort.Extension/assets/1446221/8907ef1b-d5a2-43af-a278-52eb07551adc)
Add explicit NetStandard 2.0 target to prevent that for frameworks that support NetStandard 2.0 but not Net6.0 (NetStandard 2.0, NetCoreApp and Net5.0).
This change reduce the number of dependencies to be installed for those frameworks.

For illustrate, the effect to update the library on a NET 5.0 project because of this issue.
![image](https://github.com/tompazourek/NaturalSort.Extension/assets/1446221/de3f187a-e7b1-44ac-adb8-b603c999bb81)