### PR TITLE
Switch expression in the GetTokenFromChar method

### DIFF
--- a/src/NaturalSort.Extension/NaturalSortComparer.cs
+++ b/src/NaturalSort.Extension/NaturalSortComparer.cs
@@ -191,53 +191,17 @@ public class NaturalSortComparer : IComparer<string>
 
     private static byte GetTokenFromChar(char c)
     {
-        if (c >= 'a')
+        return c switch
         {
-            if (c <= 'z')
-            {
-                return TokenLetters;
-            }
-            else if (c < 128)
-            {
-                return TokenOther;
-            }
-            else if (char.IsLetter(c))
-            {
-                return TokenLetters;
-            }
-            else if (char.IsDigit(c))
-            {
-                return TokenDigits;
-            }
-            else
-            {
-                return TokenOther;
-            }
-        }
-        else
-        {
-            if (c >= 'A')
-            {
-                if (c <= 'Z')
-                {
-                    return TokenLetters;
-                }
-                else
-                {
-                    return TokenOther;
-                }
-            }
-            else
-            {
-                if (c is >= '0' and <= '9')
-                {
-                    return TokenDigits;
-                }
-                else
-                {
-                    return TokenOther;
-                }
-            }
-        }
+            >= 'a' and <= 'z' => TokenLetters,
+            >= 'a' when c < 128 => TokenOther,
+            >= 'a' when char.IsLetter(c) => TokenLetters,
+            >= 'a' when char.IsDigit(c) => TokenDigits,
+            >= 'a' => TokenOther,
+            >= 'A' and <= 'Z' => TokenLetters,
+            >= 'A' => TokenOther,
+            >= '0' and <= '9' => TokenDigits,
+            _ => TokenOther,
+        };
     }
 }


### PR DESCRIPTION
Using switch expression in the GetTokenFromChar method slightly improves performance for .NET 8/10.

.NET 10
| Method   | Mean     | Error   | StdDev  | Ratio |
|--------- |---------:|--------:|--------:|------:|
| Sort_New | 110.3 us | 1.00 us | 0.88 us |  0.95 |
| Sort_Old | 115.6 us | 0.79 us | 0.70 us |  1.00 |

.NET 9
| Method   | Mean     | Error   | StdDev  | Ratio |
|--------- |---------:|--------:|--------:|------:|
| Sort_New | 125.3 us | 0.45 us | 0.37 us |  1.00 |
| Sort_Old | 125.5 us | 0.50 us | 0.39 us |  1.00 |


.NET 8
| Method   | Mean     | Error   | StdDev  | Ratio |
|--------- |---------:|--------:|--------:|------:|
| Sort_New | 125.2 us | 1.29 us | 1.14 us |  0.95 |
| Sort_Old | 131.4 us | 0.71 us | 0.59 us |  1.00 |